### PR TITLE
gradle.yml corrigido.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,12 +17,12 @@ on:
     paths: 
       - 'backend/**'
 
+defaults:
+  run:
+    working-directory: ./backend
+
 jobs:
   build:
-    defaults:
-      run:
-        working-directory: ./backend
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,10 +55,6 @@ jobs:
     #   run: gradle build
 
   dependency-submission:
-    defaults:
-      run:
-        working-directory: ./backend
-
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -70,6 +66,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
+        build-root-directory: ./backend
 
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
     # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md


### PR DESCRIPTION
Primeira tentativa de correção do job "dependency-submission ".

O workflow `gradle.yml` estava falhando por causa do job `dependency-submission`:

> Error: Cannot locate Gradle Wrapper script at '/home/runner/work/Profanator/Profanator/gradlew'. Specify 'gradle-version' for projects without Gradle wrapper configured.

O job não está conseguindo localizar o `gradle-wrapper`, mesmo alterando o `working-directory` para `./backend`.

Eu tentei corrigir isto adicionando uma configuração específica dessa action, que encontrei na [documentação](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#configuration-parameters) dela:

> `build-root-directory: ./backend`